### PR TITLE
added sequences

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -156,7 +156,7 @@ const main = async (opts) => {
     const key = [choirId, songId, name].join('+') + '.json'
     await cos.putObject({ Bucket: opts.definition_bucket, Key: key, Body: JSON.stringify(output) }).promise()
     console.log('written key', key)
-    return { ok: true }
+    return { ok: true, choir_id: choirId, song_id: songId, status: 'aligned' }
   } else {
     console.log('Nothing to do')
     return { ok: false }

--- a/python/convert_format.py
+++ b/python/convert_format.py
@@ -17,6 +17,7 @@ def main(args):
 
     notification = args.get('notification', {})
     key = args.get('key', notification.get('object_name', ''))
+    choir_id, song_id, part_id = Path(key).stem.split('.')[0].split('+')
 
     src_bucket = args['raw_bucket']
     dst_bucket = args['converted_bucket']
@@ -171,7 +172,11 @@ def main(args):
     ret = {'status': 'ok',
            'render_time': int(t2-t1),
            'src_key': key,
-           'dst_key': output_key
+           'dst_key': output_key,
+           'choir_id': choir_id,
+           'song_id': song_id,
+           'part_id': part_id,
+           'status': 'converted'
            }
 
     return ret

--- a/python/post_production.py
+++ b/python/post_production.py
@@ -203,7 +203,10 @@ def main(args):
         ret = {'dst_key': output_key,
                'def_id': def_id,
                'render_time': int(t2-t1),
-               'status': 'ok'}
+               'status': 'ok',
+               'choir_id': choir_id,
+               'song_id': song_id,
+               'status': 'done'}
 
         return ret
 

--- a/python/renderer_final.py
+++ b/python/renderer_final.py
@@ -45,11 +45,19 @@ def main(args):
 
     # Calc hash of found parts to make sure we have all, if not abort
     if calc_hash_of_keys(row_keys) != rows_hash:
-        ret = {'status': 'missing rows'}
+        # add choir_id/song_id/status for render status updates
+        # if we arrive here, not all parts are rendered yet, so status = 'rendered'
+        ret = {'status': 'missing rows', 'choir_id': choir_id, 'song_id': song_id, 'status': 'rendered'}
         return ret
 
     args['row_keys'] = row_keys
-    return process(args)
+    r = process(args)
+    # render status data
+    # if we arrive here, all parts are rendered, so status = 'composited'
+    r['choir_id'] = choir_id
+    r['song_id'] = song_id
+    r['status'] = 'composited'
+    return r
 
 @mqtt_status()
 def process(args):

--- a/python/snapshot.py
+++ b/python/snapshot.py
@@ -12,6 +12,7 @@ def main(args):
 
     notification = args.get('notification', {})
     key = notification.get('object_name', args['key'])
+    choir_id, song_id, part_id = Path(key).stem.split('.')[0].split('+')
     bucket = args.get('bucket', notification.get('bucket_name', args['preview_bucket']))
     dst_bucket = args.get('dst_bucket', args['snapshots_bucket'])
 
@@ -53,6 +54,10 @@ def main(args):
     stdout, stderr = out.run()
 
     ret = {"status": "ok",
-           "snapshot_key": output_key}
+           "snapshot_key": output_key,
+           "choir_id": choir_id,
+           "song_id": song_id,
+           "part_id": part_id,
+           "status": "new"}
 
     return ret


### PR DESCRIPTION
In order to get a sense of how the render status is progressing, I've added sequences to most of the renderer workflows. Here's a picture:

![choirless buckets and actions (3)](https://user-images.githubusercontent.com/697925/97423803-b78f0100-1907-11eb-8769-7fbc882ed6e6.png)

The work in this ticket was mainly checking that the serverless functions returned an object/dictionary that contains the choir_id/song_id/part_id/status so that the `renderer_status` can call the API to update the status of the job correctly.

The new sequences are labelled in pink in the diagram. Note that `renderer_compositor_main`/`renderer_compositor_child` doesn't have sequence, but `renderer_final` does update the status to either "rendered" or "composited" during the next stage.

